### PR TITLE
feat: add custom snippets

### DIFF
--- a/client/testData/.vscode/settings.json
+++ b/client/testData/.vscode/settings.json
@@ -15,5 +15,12 @@
             "needsJson": "${workspaceFolder}/doc1/needs.json",
             "srcDir": "${workspaceFolder}/doc1"
         }
+    ],
+    "sphinx-needs.ideSnippets": [
+        {
+            "needsType": "req",
+            "snippetStart": ":::",
+            "snippet": "{req} ${1:Title}\n:id: ${2:NeedID}\n\n${3:Content}"
+        }
     ]
 }

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -13,3 +13,27 @@ Example:
 
 .. image:: /_images/multiDocs.gif
    :align: center
+
+
+Custom Code Completion
+----------------------
+
+If the provided *needs*-snippets are not sufficient, custom snippets can be provided within the
+`.vscode/settings.json` file.
+
+This also includes custom snippets activation pattern, which enables custom snippets to be
+written for other file formats (e.g., markdown) as well.
+
+Example:
+
+.. code-block:: json
+   
+   {
+      "sphinx-needs.ideSnippets": [
+         {
+               "needsType": "req",
+               "snippetStart": ":::",
+               "snippet": "{req} ${1:Title}\n:id: ${2:NeedID}\n\n${3:Content}"
+         }
+      ]
+   }

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -5,10 +5,10 @@ Features
 
 .. _code_completion:
 
-Code Completion
+Custom Code Completion
 ---------------
 
-The extension supports "**code completion**" which inserts a *need* directive with some predefined options.
+The extension supports "**code completion**" which inserts a user-defined *need* directive with custom options.
 
 .. image:: /_images/features_code_completion_snippets.gif
    :align: center

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -745,7 +745,7 @@ connection.onCompletion((_textDocumentPosition: TextDocumentPositionParams): Com
 	wsConfigs.ideSnippets.forEach((ideSnippet) => {
 		if (context_word.startsWith(ideSnippet.snippetStart)) {
 			directive_items.push({
-				label: [ideSnippet.snippetStart, ideSnippet.snippet].join(" "),
+				label: [ideSnippet.snippetStart, ideSnippet.snippet].join(' '),
 				insertText: ideSnippet.snippet,
 				insertTextFormat: InsertTextFormat.Snippet,
 				kind: CompletionItemKind.Snippet


### PR DESCRIPTION
# Intention of this PR
I would like to use Sphinx-Needs in a markdown-environment instead of `.rst`. Consequently, the formatting of the provided snippets within this extension do not work for me. 

With this PR, I tried to formulate a generic approach on how to provide snippets for the extension. This was done by adding an additional field in the configuration file, where users can provide their own snippets as well as the triggering characters.

# Important information
This is my very first time writing code in TypeScript and contributing to a VS Code extension. Consequently, please see this as an initial approach or idea and feel free to criticise! I am happy to expand upon it, if you like it and contribute to your extension in the future. :)