### PR TITLE
fix: auto-generate specific IDs

### DIFF
--- a/client/src/test/extension.test.ts
+++ b/client/src/test/extension.test.ts
@@ -28,12 +28,12 @@ suite('Sphinx-Needs Extension Tests for rst file', function () {
 				{
 					label: '.. req::',
 					kind: vscode.CompletionItemKind.Snippet,
-					insertText: ' req:: Dummy Title\n\t:id: NeedID\n\t:status: open\n\n\tContent.'
+					insertText: ' req:: ${1:Dummy Title}\n\t:id: ${2:REQ_}\n\t:status: ${3:open}\n\n\t${4:Content}.'
 				},
 				{
 					label: '.. spec::',
 					kind: vscode.CompletionItemKind.Snippet,
-					insertText: ' spec:: Dummy Title\n\t:id: NeedID\n\t:status: open\n\n\tContent.'
+					insertText: ' spec:: ${1:Dummy Title}\n\t:id: ${2:SPEC_}\n\t:status: ${3:open}\n\n\t${4:Content}.'
 				}
 			]
 		};

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -842,7 +842,7 @@ connection.onCompletion((_textDocumentPosition: TextDocumentPositionParams): Com
 			{
 				label: ':need:',
 				detail: 'need role',
-				insertText: 'need:`ID`',
+				insertText: 'need:`${1:ID}`',
 				insertTextFormat: InsertTextFormat.Snippet,
 				kind: CompletionItemKind.Snippet
 			},


### PR DESCRIPTION
This PR aims to fix issue #33 while simultaneously adding the minor feature of tabbing through the fields of a snippet (I think this was present at some earlier version, but was broken later on).

IMPORTANT: Within the `needs.json`-file the information about the prefixes configured in the `conf.py` is not present and consequently, I wrote a very simple algorithm that calculates the prefix from the given needs. In turn, the auto-generated prefex is not guaranteed to be identical to the prefix configured in the `conf.py`!