### PR TITLE
Normalizing paths generated to make plugin OS independent.

### DIFF
--- a/client/src/needsExplorer.ts
+++ b/client/src/needsExplorer.ts
@@ -446,11 +446,13 @@ export class NeedsExplorerProvider implements vscode.TreeDataProvider<vscode.Tre
 			const all_files_path: string[] = [];
 			let need_doc_path: string;
 			const needs_per_doc: NeedsPerDoc = {};
+
+            		const path = require('path'); //to get the proper file separator character
 			Object.values(needs_objects).forEach((nd) => {
-				if (curr_src_dir.endsWith('/')) {
-					need_doc_path = curr_src_dir + nd.docname + nd.doctype;
+				if (curr_src_dir.endsWith(path.sep)) {
+					need_doc_path = path.normalize(curr_src_dir + nd.docname + nd.doctype);
 				} else {
-					need_doc_path = curr_src_dir + '/' + nd.docname + nd.doctype;
+					need_doc_path = path.normalize(curr_src_dir + path.sep + nd.docname + nd.doctype);
 				}
 
 				if (all_files_path.indexOf(need_doc_path) === -1) {

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "@types/mocha": "^9.1.0",
     "@types/node": "^16.11.7",
     "esbuild": "^0.15.16",
+    "git-user-name": "^2.0.0",
     "gts": "^3.1.1",
     "mocha": "^9.2.1",
     "typescript": "^4.9.3"

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
         "url": ""
     },
     "dependencies": {
+        "git-user-name": "^2.0.0",
         "vscode-languageserver": "8.0.2",
         "vscode-languageserver-textdocument": "1.0.7"
     },


### PR DESCRIPTION
Currently the vscode plugin works only on unix or linux based system. This fixes it by using path seperator module and uri module to extract or generate paths. 